### PR TITLE
TEL-2591 add asg name and instance id to logs

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/hmrc/telemetry-lambda-resources",
-  "commit": "e4e14271f1ff57463831fca7c2a8904acfedbf3c",
+  "commit": "de2955c611c3eb9a6d9b6bdacbbae579a4230c9e",
   "context": {
     "cookiecutter": {
       "bandit_skip_tests": "",

--- a/src/handler.py
+++ b/src/handler.py
@@ -63,6 +63,9 @@ def lambda_handler(event, context):
         instance_id = event["Payload"]["ec2_instance_id"]
         lifecycle_hook_name = event["Payload"]["lifecycle_hook_name"]
 
+        logger.append_keys(asg_name=auto_scaling_group_name)
+        logger.append_keys(instance_id=instance_id)
+
         if not all([auto_scaling_group_name, instance_id, lifecycle_hook_name]):
             logger.error(f"Empty key in event: {json.dumps(event)}")
             raise MissingEventParamsException(


### PR DESCRIPTION
What did we do?
--

1. Added asg name and instance id to ec2 launch check logs

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-2591

Evidence of work
--

1. tested in mdtp-integration and new fields are added to logs:
<img width="610" alt="image" src="https://user-images.githubusercontent.com/18111914/225035784-a09ad547-d910-42de-a494-7b86774cb46f.png">
