### PR TITLE
TEL-3918 use new endpoint

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -82,14 +82,12 @@ def lambda_handler(event, context):
             f"Incorrect type passed to function: {te}"
         ) from te
 
-    asg_specific_endpoint = "healthz"
     ip_address = get_instance_ip(instance_id)
-    logger.debug(f"ip_address: {ip_address}")
+    url = f"http://{ip_address}:9876/ec2-launch-checks"
 
     goss_test_pass = False
     try:
-        url = f"http://{ip_address}:9999/{asg_specific_endpoint}"
-        logger.debug(f"Calling URL {url}")
+        logger.debug(f"Calling Goss endpoint: {url}")
         endpoint_call = requests.get(url, timeout=30)
         logger.info(f"Goss endpoint. Status Code: {endpoint_call.status_code}")
         logger.debug(f"Goss endpoint. Content: {endpoint_call.text}")

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -172,7 +172,9 @@ def test_goss_succeeds_completes_lifecycle_action(
         service_response=autoscaling_complete_lifecycle_action_response_valid,
     )
 
-    requests_mock.get(f"http://10.1.3.1:9999/healthz", text=valid_goss_content())
+    requests_mock.get(
+        f"http://10.1.3.1:9876/ec2-launch-checks", text=valid_goss_content()
+    )
 
     # Act
     lambda_handler(asg_event, context)
@@ -195,7 +197,9 @@ def test_that_the_lambda_handler_catches_complete_lifecycle_action_exception(
         service_response=ec2_response,
     )
 
-    requests_mock.get(f"http://10.1.3.1:9999/healthz", text=valid_goss_content())
+    requests_mock.get(
+        f"http://10.1.3.1:9876/ec2-launch-checks", text=valid_goss_content()
+    )
 
     # Set up service error code
     service_error_code_expected = "ResourceContention"
@@ -362,7 +366,7 @@ def test_goss_returns_error_throws_exception(
         service_response=ec2_response,
     )
 
-    requests_mock.get(f"http://10.1.3.1:9999/healthz", status_code=500)
+    requests_mock.get(f"http://10.1.3.1:9876/ec2-launch-checks", status_code=500)
 
     # Act
     with pytest.raises(FailedGossCheckException) as error_message:
@@ -386,7 +390,8 @@ def test_goss_connection_timeout_throws_exception(
     )
 
     requests_mock.get(
-        f"http://10.1.3.1:9999/healthz", exc=requests.exceptions.ConnectTimeout
+        f"http://10.1.3.1:9876/ec2-launch-checks",
+        exc=requests.exceptions.ConnectTimeout,
     )
 
     # Act


### PR DESCRIPTION
What did we do?
--

1. update the goss endpoint from `healthz` to `ec2-launch-checks`
2. update the goss port number from `9999` to `9876`

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-3918

Evidence of work
--

1. n/a

Next Steps
--

1. Merge and roll out to lower environments

Risks
--

1. We control deployment via version number so risk is only in lower envs

Collaboration
--

Co-authored-by: Ali Bahman <1422984+webit4me@users.noreply.github.com>
